### PR TITLE
Fix harmcore (again)

### DIFF
--- a/R/assets.R
+++ b/R/assets.R
@@ -5,3 +5,8 @@ pc_labels_flat <- c("C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", 
 
 music_keys <- c(paste0(pc_labels_flat, "major"),
                 paste0(pc_labels_flat, "minor"))
+
+
+chord_type_levels <- c("major", "minor")
+
+short_chord_type_levels <- c("maj", "min")

--- a/R/melody_factory.R
+++ b/R/melody_factory.R
@@ -129,7 +129,9 @@ melody_factory <- R6::R6Class("Melody",
         }
 
         if(transform_check("implicit_harmonies")) {
+
           segmentation <- self$resolve_segmentation()
+
           ih <- get_implicit_harmonies(private$.mel_data$pitch,
                                        segmentation = private$.mel_data[[segmentation]],
                                        only_winner = TRUE)
@@ -155,8 +157,6 @@ melody_factory <- R6::R6Class("Melody",
           return("bar")
         }
 
-        #logging:loginfo("private$.mel_data: %s", private$.mel_data)
-
         if(!self$has("phrase_segmentation")) {
 
           seg_df <- private$.mel_data %>%
@@ -164,31 +164,8 @@ melody_factory <- R6::R6Class("Melody",
             dplyr::select(phrasbeg, phrasend) %>%
             dplyr::mutate(phrase_segmentation = cumsum(phrasbeg))
 
-          private$.mel_data <- dplyr::bind_cols(private$.mel_data, seg_df)
-            select(phrasbeg, phrasend) %>%
-            mutate(phrase_segmentation = cumsum(phrasbeg))
-          private$.mel_data <- private$.mel_data %>% remove_cols(names(phrase_segmentation))
-          private$.mel_data <- bind_cols(private$.mel_data, phrase_segmentation)
-        }
-
-        if(transform_check("implicit_harmonies")) {
-          #browser()
-          if(self$has(segmentation)) {
-            segmentation_info <- private$.mel_data[[segmentation]]
-            ih <- get_implicit_harmonies(private$.mel_data$pitch, segmentation = segmentation_info) %>%
-              select(segment, implicit_harmonies = key)
-            segmentation_name <- sym(segmentation)
-            private$.mel_data <- private$.mel_data %>%
-              remove_cols("implicit_harmonies") %>%
-              left_join(ih, by = setNames("segment", as.character(segmentation_name)) )
-          } else {
-            segmentation <- private$.mel_data$phrase_segmentation
-            ih <- get_implicit_harmonies(private$.mel_data$pitch, segmentation = segmentation) %>%
-              select(segment, implicit_harmonies = key)
-            private$.mel_data <- private$.mel_data %>%
-              left_join(ih, by = c("phrase_segmentation" = "segment"))
-          }
-
+          private$.mel_data <- dplyr::bind_cols(private$.mel_data, seg_df) %>%
+              dplyr::mutate(phrase_segmentation = cumsum(phrasbeg))
         }
 
         return("phrase_segmentation")

--- a/R/optimizers.R
+++ b/R/optimizers.R
@@ -75,37 +75,52 @@ optim_transposer_ih <- function(mel1,
                                    strategy = c("all", "hints", "best")
                                  ),
                                 ...) {
+
   mel1$pitch <- mel1$pitch + 60 - min(c(mel1$pitch))
   mel2$pitch <- mel2$pitch + 60 - min(c(mel2$pitch))
-  if(is.null(parameters)){
+
+  if (is.null(parameters)) {
     parameters <- list(strategy = "all")
   }
   strategy <- parameters$strategy[1]
 
   d <- stats::median(mel2$pitch)  -  stats::median(mel1$pitch)
 
-  if(strategy == "all") {
+  if (strategy == "all") {
     hints <- 0:11
   }
-  else if(strategy == "hints") {
-    hints <- get_transposition_hints(mel2$pitch, mel1$pitch )
+  else if (strategy == "hints") {
+    hints <- get_transposition_hints(mel2$pitch, mel1$pitch)
   }
-  else if(strategy == "best") {
+  else if (strategy == "best") {
     hints <- find_best_transposition(mel2$pitch, mel1$pitch)
   }
 
-  ih1 <- get_implicit_harmonies(mel1$pitch, segmentation = mel1$bar)
-  ih2 <- get_implicit_harmonies(mel2$pitch, segmentation = mel2$bar)%>%
-    mutate(symbols = key_pc  + 12 * as.integer(factor(type))- 12) %>%
+  if("bar" %in% names(mel1)) {
+    mel1_seg <- mel1$bar
+    mel2_seg <- mel2$bar
+  } else if("phrase_segmentation" %in% names(mel1)) {
+    mel1_seg <- mel1$phrase_segmentation
+    mel2_seg <- mel2$phrase_segmentation
+  } else {
+    mel1_seg <- NULL
+    mel2_seg <- NULL
+  }
+
+
+  ih1 <- get_implicit_harmonies(mel1$pitch, segmentation = mel1_seg)
+
+  ih2 <- get_implicit_harmonies(mel2$pitch, segmentation = mel2_seg) %>%
+    mutate(symbols = key_pc + 12 * (match(type, chord_type_levels) - 1)) %>%
     pull(symbols)
 
   ret <- purrr::map_dfr(union(d, hints) %% 12, function(trans) {
-    #browser()
-    ih1_trans <- (ih1$key_pc + trans) %% 12 + 12 * as.integer(factor(ih1$type))- 12
-    tibble(trans = trans,
-           sim = sim_measure(ih1_trans, ih2))
+
+    ih1_trans <- (ih1$key_pc + trans) %% 12 + 12 * as.integer(factor(ih1$type)) - 12
+    tibble(trans = trans, sim = sim_measure(ih1_trans, ih2))
   })
-  #browser()
+
+
   ret %>% pull(sim) %>% max()
 }
 


### PR DESCRIPTION
Harmcore was still not fixed for me. I got an error in resolve segmentation (missing %>% pipe)



But also there were several other issues:


- missing handling for phrase segmentation other than bar (which is our use case presently)
- mixing of segmentation and implicit harmony producing logic
- inconsistent behaviour with the new IH transposer due to not keeping factor level orders the same

I think this patch fixes those things and I now get the results I am expecting for our paper simulations.



Please proof and roll into master if you agree, @klausfrieler.



All the best,

Seb